### PR TITLE
detectRetina has to be false

### DIFF
--- a/app/view/map/NavigationView.js
+++ b/app/view/map/NavigationView.js
@@ -30,7 +30,7 @@ Ext.define('Denkmap.view.map.NavigationView', {
             tileLayerOptions: {
                 apikey: Denkmap.util.Config.getLeafletMap().apiKey,
                 attribution: Denkmap.util.Config.getLeafletMap().tileLayerAttribution,
-                detectRetina: true
+                detectRetina: false
             }
         }],
 


### PR DESCRIPTION
Because we (Lyrk) are already providing 512x512 tiles, no further scaling (detectRetina) is needed otherwise the fonts on mobile devices are really tiny.
